### PR TITLE
Upgraded v8 to v9 as v8 returned status 410

### DIFF
--- a/full_offline_backup_for_todoist/todoist_api.py
+++ b/full_offline_backup_for_todoist/todoist_api.py
@@ -19,7 +19,7 @@ class TodoistProjectInfo:
 class TodoistApi:
     """ Provides access to a subset of the features of the Todoist API"""
 
-    __BASE_URL = "https://api.todoist.com/sync/v8"
+    __BASE_URL = "https://api.todoist.com/sync/v9"
     __SYNC_ENDPOINT = __BASE_URL + "/sync"
     __EXPORT_PROJECT_AS_CSV_FILE_ENDPOINT = __BASE_URL + "/templates/export_as_file"
 


### PR DESCRIPTION
Since two or three days, the v8 API returns Status 410 gone. I did not test every functionality, but the default export is still working without any changes other than the API version. I ran the following command:

`python3 -m full_offline_backup_for_todoist download --output-file out.zip`

