### PR TITLE
Use absolute dates instead of relatives by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ To create a backup from Todoist's servers, including attachments, and with traci
 
 ``python3 -m full_offline_backup_for_todoist --verbose download --with-attachments``
 
+If you prefer relative dates in the CSV export (e.g. "in 259 days" instead of "November 29, 2026"), add `--use-relative-dates` to the end of your command.
+
 Print full help:
 
 ``python3 -m full_offline_backup_for_todoist -h``

--- a/full_offline_backup_for_todoist/frontend.py
+++ b/full_offline_backup_for_todoist/frontend.py
@@ -12,7 +12,7 @@ from .controller import TodoistAuth, Controller, ControllerDependencyInjector
 class ConsoleFrontend:
     """ Implementation of the console frontend for the Todoist backup tool """
     def __init__(self, controller_factory: Callable[[ControllerDependencyInjector], Controller],
-                 controller_dependencies_factory: Callable[[TodoistAuth, bool],
+                 controller_dependencies_factory: Callable[[TodoistAuth, bool, bool],
                                                            ControllerDependencyInjector]):
         self.__controller_factory = controller_factory
         self.__controller_dependencies_factory = controller_dependencies_factory
@@ -46,6 +46,8 @@ class ConsoleFrontend:
                                      help="download attachments and attach to the backup file")
         parser_download.add_argument("--output-file", type=str,
                                      help="name of the file that will store the backup")
+        parser_download.add_argument("--use-relative-dates", action="store_true",
+                                     help="export dates as relative (e.g. 'in 12 days') in CSV")
         self.__add_authorization_group(parser_download)
 
         return parser.parse_args(arguments)
@@ -100,7 +102,8 @@ class ConsoleFrontend:
 
         # Configure controller
         auth = self.__get_auth(args, environment)
-        dependencies = self.__controller_dependencies_factory(auth, args.verbose)
+        dependencies = self.__controller_dependencies_factory(
+            auth, args.verbose, args.use_relative_dates)
         controller = self.__controller_factory(dependencies)
 
         # Setup zip virtual fs

--- a/full_offline_backup_for_todoist/runtime.py
+++ b/full_offline_backup_for_todoist/runtime.py
@@ -11,10 +11,10 @@ from .url_downloader import URLLibURLDownloader
 class RuntimeControllerDependencyInjector(ControllerDependencyInjector):
     """ Implementation of the dependency injection container for the actual runtime objects """
 
-    def __init__(self, auth: TodoistAuth, verbose: bool):
+    def __init__(self, auth: TodoistAuth, verbose: bool, use_relative_dates: bool):
         self.__tracer = ConsoleTracer() if verbose else NullTracer()
         urldownloader = URLLibURLDownloader(self.__tracer)
-        todoist_api = TodoistApi(auth.token, self.__tracer, urldownloader)
+        todoist_api = TodoistApi(auth.token, self.__tracer, urldownloader, use_relative_dates)
         self.__backup_downloader = TodoistBackupDownloader(self.__tracer, todoist_api)
         self.__backup_attachments_downloader = TodoistBackupAttachmentsDownloader(
             self.__tracer, urldownloader)

--- a/full_offline_backup_for_todoist/todoist_api.py
+++ b/full_offline_backup_for_todoist/todoist_api.py
@@ -25,11 +25,14 @@ class TodoistApi:
 
     __tracer: Tracer
     __urldownloader: URLDownloader
+    __use_relative_dates: bool
 
-    def __init__(self, api_token: str, tracer: Tracer, urldownloader: URLDownloader):
+    def __init__(self, api_token: str, tracer: Tracer, urldownloader: URLDownloader,
+                 use_relative_dates: bool = False):
         self.__tracer = tracer
         self.__urldownloader = urldownloader
         self.__urldownloader.set_bearer_token(api_token)
+        self.__use_relative_dates = use_relative_dates
 
     def get_projects(self) -> List[TodoistProjectInfo]:
         """ Obtains the list of all projects from the Todoist API """
@@ -53,5 +56,6 @@ class TodoistApi:
 
         return self.__urldownloader.get(
             self.__TEMPLATES_CSV_FILE_ENDPOINT, {
-                "project_id": project.identifier
+                "project_id": project.identifier,
+                "use_relative_dates": str(self.__use_relative_dates).lower(),
             })

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -31,19 +31,19 @@ class TestIntegration(unittest.TestCase):
         route_responses = {
             ("POST", "/https://api.todoist.com/api/v1/sync", b"sync_token=%2A&resource_types=%5B%22projects%22%5D", 'mysecrettoken'):
                 Path(self.__get_test_file("sources/project_list.json")).read_bytes(),
-            ("GET", "/https://api.todoist.com/api/v1/templates/file?project_id=2181147955", None, 'mysecrettoken'):
+            ("GET", "/https://api.todoist.com/api/v1/templates/file?project_id=2181147955&use_relative_dates=false", None, 'mysecrettoken'):
                 Path(self.__get_test_file("sources/Project_2181147955.csv")).read_bytes(),
-            ("GET", "/https://api.todoist.com/api/v1/templates/file?project_id=2181147714", None, 'mysecrettoken'):
+            ("GET", "/https://api.todoist.com/api/v1/templates/file?project_id=2181147714&use_relative_dates=false", None, 'mysecrettoken'):
                 Path(self.__get_test_file("sources/Project_2181147714.csv")).read_bytes(),
-            ("GET", "/https://api.todoist.com/api/v1/templates/file?project_id=2181147709", None, 'mysecrettoken'):
+            ("GET", "/https://api.todoist.com/api/v1/templates/file?project_id=2181147709&use_relative_dates=false", None, 'mysecrettoken'):
                 Path(self.__get_test_file("sources/Project_2181147709.csv")).read_bytes(),
-            ("GET", "/https://api.todoist.com/api/v1/templates/file?project_id=2181147715", None, 'mysecrettoken'):
+            ("GET", "/https://api.todoist.com/api/v1/templates/file?project_id=2181147715&use_relative_dates=false", None, 'mysecrettoken'):
                 Path(self.__get_test_file("sources/Project_2181147715.csv")).read_bytes(),
-            ("GET", "/https://api.todoist.com/api/v1/templates/file?project_id=2181147711", None, 'mysecrettoken'):
+            ("GET", "/https://api.todoist.com/api/v1/templates/file?project_id=2181147711&use_relative_dates=false", None, 'mysecrettoken'):
                 Path(self.__get_test_file("sources/Project_2181147711.csv")).read_bytes(),
-            ("GET", "/https://api.todoist.com/api/v1/templates/file?project_id=2181147712", None, 'mysecrettoken'):
+            ("GET", "/https://api.todoist.com/api/v1/templates/file?project_id=2181147712&use_relative_dates=false", None, 'mysecrettoken'):
                 Path(self.__get_test_file("sources/Project_2181147712.csv")).read_bytes(),
-            ("GET", "/https://api.todoist.com/api/v1/templates/file?project_id=2181147713", None, 'mysecrettoken'):
+            ("GET", "/https://api.todoist.com/api/v1/templates/file?project_id=2181147713&use_relative_dates=false", None, 'mysecrettoken'):
                 Path(self.__get_test_file("sources/Project_2181147713.csv")).read_bytes(),
             ("GET", "/https://d1x0mwiac2rqwt.cloudfront.net/g75-kL8pwVYNObSczLnVXe4FIyJd8YQL6b8yCilGyix09bMdJmxbtrGMW9jIeIwJ/by/16542905/as/bug.txt", None, None):
                 Path(self.__get_test_file("sources/bug.txt")).read_bytes(),

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -14,7 +14,7 @@ class TestRuntime(unittest.TestCase):
         # Arrange
 
         # Act
-        runtimedi = RuntimeControllerDependencyInjector(TodoistAuth("1234"), False)
+        runtimedi = RuntimeControllerDependencyInjector(TodoistAuth("1234"), False, False)
         tracer1 = runtimedi.tracer
         tracer2 = runtimedi.tracer
         backup_downloader1 = runtimedi.backup_downloader

--- a/tests/test_todoist_api.py
+++ b/tests/test_todoist_api.py
@@ -4,7 +4,7 @@
 import unittest
 import json
 from unittest.mock import MagicMock, ANY
-from full_offline_backup_for_todoist.todoist_api import TodoistApi
+from full_offline_backup_for_todoist.todoist_api import TodoistApi, TodoistProjectInfo
 from full_offline_backup_for_todoist.url_downloader import URLDownloaderException
 from full_offline_backup_for_todoist.tracer import NullTracer
 
@@ -91,3 +91,28 @@ class TestTodoistApi(unittest.TestCase):
 
         # Act/Assert
         self.assertRaises(URLDownloaderException, todoist_api.get_projects)
+
+    def test_export_project_csv_passes_relative_dates_flag(self):
+        """ Tests that relative dates flag is passed to the export endpoint """
+        # Arrange
+        mock_urldownloader = MagicMock()
+        mock_urldownloader.get.return_value = b"csv-data"
+        project = TodoistProjectInfo("Work", 123)
+
+        # Act
+        TodoistApi("FAKE_TOKEN", NullTracer(), mock_urldownloader, False).export_project_as_csv(
+            project
+        )
+        TodoistApi("FAKE_TOKEN", NullTracer(), mock_urldownloader, True).export_project_as_csv(
+            project
+        )
+
+        # Assert
+        mock_urldownloader.get.assert_any_call(ANY, {
+            "project_id": 123,
+            "use_relative_dates": "false",
+        })
+        mock_urldownloader.get.assert_any_call(ANY, {
+            "project_id": 123,
+            "use_relative_dates": "true",
+        })


### PR DESCRIPTION
Hi! Thank you for this project. Here is some change I suggest: pass `use_relative_dates=false` to API calls. Personally, I don't understand why it defaults to true in the Todoist API, and what kind of use cases can there be with `use_relative_dates=true`.

Examples of exported file diffs (my locale is Russian):

```diff
-- удалить папку после получения вычета",,4,1,m_danya (30672594),,in 34 days,en,Europe/Moscow,,,,
+- удалить папку после получения вычета",,4,1,m_danya (30672594),,7 мар 2026,ru,Europe/Moscow,,,,^M
```

```diff
-task,[Brackeys Game Jam 2026.1](https://itch.io/jam/brackeys-15) ДЖЕМ,,,4,1,m_danya (30672594),,in 13 days,en,Europe/Moscow,,,,
+task,[Brackeys Game Jam 2026.1](https://itch.io/jam/brackeys-15) ДЖЕМ,,,4,1,m_danya (30672594),,14 февр 2026,ru,Europe/Moscow,,,,^M
```